### PR TITLE
moced type dependecies from dev to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/react": "^18.0.17",
+    "@types/react-dom": "^18.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.17",
-    "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.0.1",
     "typescript": "^4.6.4",
     "vite": "^3.0.7"


### PR DESCRIPTION
is this really necessary? Types should be for the typescript compiler and are not required in the output files, everything need should edbe there in either case. It mae.
